### PR TITLE
Claude Codeアクションの使用を、Akira-Papaからlangcore-orgのリポジトリに変更しました。

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 1
 
       - name: Auto review PR
-        uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+        uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: Akira-Papa/claude-code-action@beta
+        uses: langcore-org/claude-code-action@beta
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Fork Changes (Akira-Papa/claude-code-action@beta)
+## Fork Changes (langcore-org/claude-code-action@beta)
 
 This is a fork of the official Claude Code Action that adds OAuth authentication support for Claude Max subscribers.
 
@@ -11,7 +11,7 @@ This is a fork of the official Claude Code Action that adds OAuth authentication
   - New input: `claude_access_token` - OAuth access token from Claude Max subscription
   - New input: `claude_refresh_token` - OAuth refresh token from Claude Max subscription
   - New input: `claude_expires_at` - Token expiration timestamp
-- **Updated Base Action**: Uses `Akira-Papa/claude-code-base-action@beta` which includes OAuth credential handling
+- **Updated Base Action**: Uses `langcore-org/claude-code-base-action@beta` which includes OAuth credential handling
 
 ### Changed
 
@@ -28,7 +28,7 @@ This is a fork of the official Claude Code Action that adds OAuth authentication
    - `CLAUDE_EXPIRES_AT`
 3. Enable OAuth in your workflow:
    ```yaml
-   - uses: Akira-Papa/claude-code-action@beta
+   - uses: langcore-org/claude-code-action@beta
      with:
        use_oauth: "true"
        claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
   claude-response:
     runs-on: ubuntu-latest
     steps:
-      - uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+      - uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
         with:
           # Option 1: Direct API (default)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -194,7 +194,7 @@ on:
       - "src/api/**/*.ts"
 
 steps:
-  - uses: Akira-Papa/claude-code-action@beta
+  - uses: langcore-org/claude-code-action@beta
     with:
       direct_prompt: |
         Update the API documentation in README.md to reflect
@@ -218,7 +218,7 @@ jobs:
       github.event.pull_request.user.login == 'developer1' ||
       github.event.pull_request.user.login == 'external-contributor'
     steps:
-      - uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+      - uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
         with:
           direct_prompt: |
             Please provide a thorough review of this pull request.
@@ -236,7 +236,7 @@ Perfect for automatically reviewing PRs from new team members, external contribu
 4. **Branch Management**: Creates new PRs for human authors, pushes directly for Claude's own PRs
 5. **Communication**: Posts updates at every step to keep you informed
 
-This action is built on top of [`Akira-Papa/claude-code-base-action`](https://github.com/Akira-Papa/claude-code-base-action).
+This action is built on top of [`langcore-org/claude-code-base-action`](https://github.com/langcore-org/claude-code-base-action).
 
 ## Capabilities and Limitations
 
@@ -277,7 +277,7 @@ Claude does **not** have access to execute arbitrary Bash commands by default. I
 **Note**: If your repository has a `.mcp.json` file in the root directory, Claude will automatically detect and use the MCP server tools defined there. However, these tools still need to be explicitly allowed via the `allowed_tools` configuration.
 
 ```yaml
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
   with:
     allowed_tools: "Bash(npm install),Bash(npm run test),Edit,Replace,NotebookEditCell"
     disallowed_tools: "TaskOutput,KillTask"
@@ -291,7 +291,7 @@ Claude does **not** have access to execute arbitrary Bash commands by default. I
 Use a specific Claude model:
 
 ```yaml
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
   with:
     # model: "claude-3-5-sonnet-20241022"  # Optional: specify a different model
     # ... other inputs
@@ -320,13 +320,13 @@ Use provider-specific model names based on your chosen provider:
 
 ```yaml
 # For direct Anthropic API (default)
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
   with:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     # ... other inputs
 
 # For OAuth authentication (Claude Max subscribers)
-- uses: Akira-Papa/claude-code-action@beta
+- uses: langcore-org/claude-code-action@beta
   with:
     use_oauth: "true"
     claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
@@ -335,14 +335,14 @@ Use provider-specific model names based on your chosen provider:
     # ... other inputs
 
 # For Amazon Bedrock with OIDC
-- uses: Akira-Papa/claude-code-action@beta
+- uses: langcore-org/claude-code-action@beta
   with:
     model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
     use_bedrock: "true"
     # ... other inputs
 
 # For Google Vertex AI with OIDC
-- uses: Akira-Papa/claude-code-action@beta
+- uses: langcore-org/claude-code-action@beta
   with:
     model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"
@@ -368,7 +368,7 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
     app-id: ${{ secrets.APP_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
   with:
     model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
     use_bedrock: "true"
@@ -393,7 +393,7 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
     app-id: ${{ secrets.APP_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
   with:
     model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
     - name: Run Claude Code
       id: claude-code
       if: steps.prepare.outputs.contains_trigger == 'true'
-      uses: Akira-Papa/claude-code-base-action@main
+      uses: langcore-org/claude-code-base-action@main
       with:
         prompt_file: /tmp/claude-prompts/claude-prompt.txt
         allowed_tools: ${{ env.ALLOWED_TOOLS }}

--- a/examples/claude-auto-review.yml
+++ b/examples/claude-auto-review.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 1
 
       - name: Automatic PR Review
-        uses: Akira-Papa/claude-code-action@beta
+        uses: langcore-org/claude-code-action@beta
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/examples/claude-pr-path-specific.yml
+++ b/examples/claude-pr-path-specific.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 1
 
       - name: Claude Code Review
-        uses: Akira-Papa/claude-code-action@beta
+        uses: langcore-org/claude-code-action@beta
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/examples/claude-review-from-author.yml
+++ b/examples/claude-review-from-author.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: Review PR from Specific Author
-        uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+        uses: langcore-org/claude-code-action@beta  # Fork with OAuth support
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: Akira-Papa/claude-code-action@beta
+        uses: langcore-org/claude-code-action@beta
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - すべてのドキュメント内のGitHub Actionリポジトリ参照を `Akira-Papa/claude-code-action` から `langcore-org/claude-code-action` に更新しました。
  - ベースアクションのリポジトリ参照も `langcore-org/claude-code-base-action` に変更しました。

- **雑務**
  - ワークフローやサンプルファイルで使用するアクションのリポジトリ参照を新しいものに統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->